### PR TITLE
fixed the insert of user: too many values for the specified columns

### DIFF
--- a/flask_ad_auth/ad_login.py
+++ b/flask_ad_auth/ad_login.py
@@ -528,9 +528,9 @@ class SQLiteDatabase(object):
         """
         c = self.conn.cursor()
         c.execute("INSERT OR REPLACE INTO users (email, access_token, refresh_token, expires_on, "
-                  "token_type, resource, scope, groups) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                  "token_type, resource, scope, groups) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                   (user.email, user.access_token, user.refresh_token, user.expires_on,
-                   user.token_type, user.resource, user.scope, user.group_string, user.metadata))
+                   user.token_type, user.resource, user.scope, user.group_string))
         self.conn.commit()
         return user
 


### PR DESCRIPTION
Without this change, it is currently not possible to add new users to the database. There are 8 columns but there are 9 values specified.