### PR TITLE
logger warnig fix in "get_token_silent"

### DIFF
--- a/flask_ad_auth/ad_login.py
+++ b/flask_ad_auth/ad_login.py
@@ -453,7 +453,7 @@ class ADAuth(LoginManager):
         # try to migrate the refresh token to cache
         res = self.client.acquire_token_by_refresh_token(user.refresh_token, scopes=DEFAULT_SCOPE)
         if "error" in res:
-            logger.warning("Refresh Error: {}").format(res.get("error"))
+            logger.warning("Refresh Error: {}".format(res.get("error")))
             return None
         logger.info("got token from db refresh")
         return res


### PR DESCRIPTION
Original text from issue: [https://github.com/wuttem/flask-ad-auth/issues/10](url):

> Hey guys
I think I found an issue on code line 456 in ad_login.py:

> logger.warning("Refresh Error: {}").format(res.get("error"))

> If I leave this line like that I receive:

>  File "C:\Users\cedric.meier\Git\expertensystem\Lib\site-packages\flask_ad_auth\ad_login.py", line 466, in get_token_silent
  logger.warning("Refresh Error: {}").format(res.get("error"))
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'format'

> when going to localhost:5000.

> Initially I found out that there was some token error. I added:

> print("Token Response from Refresh:", res)

> underneath line 454 to check what is stored in res. I got:

>Token Response from Refresh: {'error': 'invalid_grant', 'error_description': 'AADSTS700082: The refresh token has expired due to inactivity.\xa0The token was issued on 2024-06-18T14:17:30.8187395Z and was inactive for 90.00:00:00. Trace ID: ae2952d3-6f45-4719-8300-2f85c5f96c00 Correlation ID: 1f452805-38b6-4780-9c17-ac514a4d4287 Timestamp: 2024-10-08 13:48:19Z', 'error_codes': [700082], 'timestamp': '2024-10-08 13:48:19Z', 'trace_id': 'ae2952d3-6f45-4719-8300-2f85c5f96c00', 'correlation_id': '1f452805-38b6-4780-9c17-ac514a4d4287', 'error_uri': 'https://login.microsoftonline.com/error?code=700082', 'suberror': 'bad_token'}

> My understanding of tokens is abysmal, but when i changed the line 456 from
logger.warning("Refresh Error: {}").format(res.get("error"))
to
logger.warning("Refresh Error: {}".format(res.get("error")))
everything worked when going to localhost:5000 again on restart.

> This is my first time reporting an issue. I hope i did not overlook something...
Regards!

On maintainer review I fixed as described.